### PR TITLE
Remove voice control text from mobile navbar

### DIFF
--- a/client/components/ModernNavbar.tsx
+++ b/client/components/ModernNavbar.tsx
@@ -558,13 +558,7 @@ function MobileMenu({
               >
                 Пятница
               </Link>
-              <Link
-                to="/voice-test"
-                onClick={onClose}
-                className="block p-3 text-center rounded-xl border border-green-400/30 hover:bg-green-400/10 text-green-300 transition-colors"
-              >
-                Голосовой тест
-              </Link>
+
             </>
           )}
         </div>

--- a/client/components/ModernNavbar.tsx
+++ b/client/components/ModernNavbar.tsx
@@ -523,14 +523,6 @@ function MobileMenu({
                 <span className="text-white">Чат с Пятницей 🤖</span>
               </Link>
 
-              <Link
-                to="/voice-test"
-                onClick={onClose}
-                className="flex items-center space-x-3 p-3 rounded-xl hover:bg-green-400/10 transition-colors"
-              >
-                <Brain className="w-5 h-5 text-green-400" />
-                <span className="text-white">Тест голосо��ого управл��ния</span>
-              </Link>
 
               <button
                 onClick={() => {

--- a/client/components/ModernNavbar.tsx
+++ b/client/components/ModernNavbar.tsx
@@ -523,7 +523,6 @@ function MobileMenu({
                 <span className="text-white">Чат с Пятницей 🤖</span>
               </Link>
 
-
               <button
                 onClick={() => {
                   onLogout();
@@ -558,7 +557,6 @@ function MobileMenu({
               >
                 Пятница
               </Link>
-
             </>
           )}
         </div>


### PR DESCRIPTION
## Purpose
Based on user feedback, the voice control text in the mobile navbar was requested to be removed. The user specifically asked to remove the voice control text from the mobile version navbar while keeping other functions unchanged and ensuring clean text without symbols.

## Code changes
- Removed voice control test link from authenticated mobile menu section
- Removed "Тест голосового управления" (Voice Control Test) menu item with Brain icon
- Removed "Голосовой тест" (Voice Test) link from unauthenticated mobile menu section
- Cleaned up mobile navbar by removing voice-related navigation elements while preserving all other functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/15a1dc49d01846448b5617641347065d/pulse-oasis)

👀 [Preview Link](https://15a1dc49d01846448b5617641347065d-pulse-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>15a1dc49d01846448b5617641347065d</projectId>-->
<!--<branchName>pulse-oasis</branchName>-->